### PR TITLE
Add AI debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Run the game with:
 python3 game.py
 ```
 
+You can also play against a simple computer opponent for debugging with:
+
+```bash
+python3 game.py ai
+```
+
 During each round a random animal tile is auctioned. Players bid chips and the
 winner places the tile on the grid. A player wins by either forming their secret
 sequence of three animals or fulfilling their condition card stating that one

--- a/game.py
+++ b/game.py
@@ -60,8 +60,25 @@ def choose_spot(board: Board) -> Tuple[int, int]:
             print("Invalid input. Use row,col format.")
 
 
-def run_game() -> None:
-    board: Board = [[None]*GRID_SIZE for _ in range(GRID_SIZE)]
+def ai_bid(chips: int) -> int:
+    """Return a simple bid for the computer player."""
+    return random.randint(0, chips)
+
+
+def choose_spot_ai(board: Board) -> Tuple[int, int]:
+    """Return a random free spot on the board for the computer player."""
+    available = [
+        (r, c)
+        for r in range(GRID_SIZE)
+        for c in range(GRID_SIZE)
+        if board[r][c] is None
+    ]
+    return random.choice(available)
+
+
+def run_game(ai: bool = False) -> None:
+    """Run a game. If ``ai`` is True, player 2 is computer controlled."""
+    board: Board = [[None] * GRID_SIZE for _ in range(GRID_SIZE)]
     chips = {1: 10, 2: 10}
     seq = {1: random.sample(ANIMALS, 3), 2: random.sample(ANIMALS, 3)}
     cond = {}
@@ -79,16 +96,21 @@ def run_game() -> None:
         print(f"Tile up for auction: {tile}")
         bids = {}
         for player in (1, 2):
-            while True:
-                try:
-                    bid = int(input(f"Player {player} bids (chips left {chips[player]}): "))
-                    if 0 <= bid <= chips[player]:
-                        bids[player] = bid
-                        break
-                    else:
-                        print("Invalid bid.")
-                except ValueError:
-                    print("Enter a number.")
+            if ai and player == 2:
+                bid = ai_bid(chips[player])
+                print(f"Computer bids {bid} (chips left {chips[player]})")
+                bids[player] = bid
+            else:
+                while True:
+                    try:
+                        bid = int(input(f"Player {player} bids (chips left {chips[player]}): "))
+                        if 0 <= bid <= chips[player]:
+                            bids[player] = bid
+                            break
+                        else:
+                            print("Invalid bid.")
+                    except ValueError:
+                        print("Enter a number.")
         if bids[1] == bids[2]:
             winner = random.choice([1, 2])
             print(f"Tie! Player {winner} wins the auction by coin flip.")
@@ -96,7 +118,11 @@ def run_game() -> None:
             winner = 1 if bids[1] > bids[2] else 2
         chips[winner] -= bids[winner]
         print(f"Player {winner} wins and places the tile.")
-        r, c = choose_spot(board)
+        if ai and winner == 2:
+            r, c = choose_spot_ai(board)
+            print(f"Computer chooses spot {r},{c}")
+        else:
+            r, c = choose_spot(board)
         board[r][c] = tile
 
         for player in (1, 2):
@@ -110,4 +136,6 @@ def run_game() -> None:
 
 
 if __name__ == "__main__":
-    run_game()
+    import sys
+    ai_mode = len(sys.argv) > 1 and sys.argv[1].lower() == "ai"
+    run_game(ai=ai_mode)


### PR DESCRIPTION
## Summary
- add a simple computer opponent
- support choosing AI mode via command line argument
- document new debug mode in README

## Testing
- `python3 -m py_compile game.py`
- `python3 game.py ai <<'EOF'
0
0
0,0
0
0
0,1
EOF` (sample run)
- `python3 game.py <<'EOF'
0
0
0,0
0
0
0,1
EOF` (sample run, ended early)


------
https://chatgpt.com/codex/tasks/task_e_685b6e9d9338832dbf4e3dae8dc99624