### PR TITLE
Handle keypad enter for bidding

### DIFF
--- a/visual_game.py
+++ b/visual_game.py
@@ -99,7 +99,7 @@ def get_bid_input(screen: pygame.Surface, board: Board, tile: str, player: int,
                 pygame.quit()
                 raise SystemExit
             if event.type == pygame.KEYDOWN:
-                if event.key == pygame.K_RETURN:
+                if event.key in (pygame.K_RETURN, pygame.K_KP_ENTER):
                     if text == "":
                         print("Enter a number.")
                         continue


### PR DESCRIPTION
## Summary
- handle keypad Enter (K_KP_ENTER) in the bid entry box so players can submit bids with either Enter key

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_685b854364e8832d883f9a20abf8037c